### PR TITLE
Bas 2412

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -156,9 +156,20 @@ func (h *handler) serveAuthorizationRequest(
 	// redirect_uri
 	if redir, ok := query["redirect_uri"]; ok {
 		for _, r := range client.Redirects {
-			if redir[0] == r {
-				authzState.RedirectURI = r
-				break
+			lastChar := r[len(r)-1:]
+			if lastChar == "*" {
+				// do partial string match up to the '*' character, e.g. 
+				// https://host/redirect/to/anywhere matches https://host/redirect/*
+				length := len(r) - 1
+				if r[:length] == redir[0][:length] {
+					authzState.RedirectURI = redir[0]
+					break
+				}
+			} else {
+				if redir[0] == r {
+					authzState.RedirectURI = r
+					break
+				}
 			}
 		}
 	} else if len(client.Redirects) == 1 {

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -158,14 +158,17 @@ func (h *handler) serveAuthorizationRequest(
 		for _, r := range client.Redirects {
 			lastChar := r[len(r)-1:]
 			if lastChar == "*" {
-				// do partial string match up to the '*' character, e.g. 
-				// https://host/redirect/to/anywhere matches https://host/redirect/*
 				length := len(r) - 1
-				if r[:length] == redir[0][:length] {
-					authzState.RedirectURI = redir[0]
-					break
+				if len(redir[0]) >= length {
+					// do partial string match up to the '*' character, e.g.
+					// https://host/redirect/to/anywhere will match https://host/redirect/*
+					if r[:length] == redir[0][:length] {
+						authzState.RedirectURI = redir[0]
+						break
+					}
 				}
 			} else {
+				// do an exact string match
 				if redir[0] == r {
 					authzState.RedirectURI = r
 					break


### PR DESCRIPTION
Add support for simple wildcard matching. This patch only support wildcard asterisk as last character in the string, i.e. `https://host/item/*` and not `https://host/item/*/somethingelse`.

Unit tests are updated to verify the new functionality. The existing tests have been rewritten to use a set of valid arguments and have only one exception. This makes it more explicit that every test only verifies a single invalid argument. This change was also required because some of the tests depended on the implicit mechanism that when no redirect URI is given and the client has exactly one URI, that one is chosen. Since `testclient1` was given multiple redirect URIs, the tests that didn't provide one now failed.