### PR TITLE
Set IDP callback request for GRIP to 10 seconds

### DIFF
--- a/gripidp.go
+++ b/gripidp.go
@@ -207,7 +207,7 @@ func newGripIDP(tenantID string, clientID string, clientSecret string, oauthBase
 	userInfoURL := fmt.Sprintf(gripUserInfoURL, tenantID)
 	return &gripIDP{
 		clientID, clientSecret, oauthBaseURL, authURL, tokenURL, userInfoURL,
-		roles, &http.Client{Timeout: 30 * time.Second},
+		roles, &http.Client{Timeout: 10 * time.Second},
 	}
 }
 


### PR DESCRIPTION
The timeout was increased to 30s previously for debugging purposes. The root cause of the issue was Motiv, so the timeout is set back to the original value again.